### PR TITLE
[FEAT] 프로필 이미지 null로 수정시에 리소스에서 이미지 삭제 구현

### DIFF
--- a/src/main/java/org/sparta/newsfeed/domain/common/exception/ErrorCode.java
+++ b/src/main/java/org/sparta/newsfeed/domain/common/exception/ErrorCode.java
@@ -17,7 +17,9 @@ public enum ErrorCode {
 
     COMMENT_NOT_FOUND("댓글을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
     FORBIDDEN_COMMENT_ACCESS("댓글에 대한 접근 권한이 없습니다.", HttpStatus.FORBIDDEN),
-    POST_NOT_FOUND("게시글을 찾을 수 없습니다.", HttpStatus.NOT_FOUND);
+    POST_NOT_FOUND("게시글을 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+
+    IMAGE_DELETE_FAIL("이미지 삭제에 실패했습니다.", HttpStatus.INTERNAL_SERVER_ERROR);
 
     private final String message;
     private final HttpStatus status;

--- a/src/main/java/org/sparta/newsfeed/domain/profiles/controller/ProfileController.java
+++ b/src/main/java/org/sparta/newsfeed/domain/profiles/controller/ProfileController.java
@@ -44,7 +44,7 @@ public class ProfileController {
     @PutMapping("/{id}")
     public ResponseEntity<ProfileResponseDto> updateProfile(
             @PathVariable Long id,
-            @Valid @ModelAttribute ProfileUpdateRequestDto profileUpdateRequestDto,  // @Valid와 @ModelAttribute 사용
+            @Valid @ModelAttribute ProfileUpdateRequestDto profileUpdateRequestDto,
             @RequestAttribute("userId") Long userId) throws IOException {
         // 접근 권한이 없으면 예외 발생
         if (!userId.equals(id)) {


### PR DESCRIPTION
프로필 이미지를 설정하지 않을 경우, 기존에 업로드 했던 사진을 리소스에서 삭제하도록 변경했습니다. 